### PR TITLE
Add the ability to send CreditCard e-mail via Auth/Capture API calls.

### DIFF
--- a/authorize/apis/transaction.py
+++ b/authorize/apis/transaction.py
@@ -71,7 +71,7 @@ class TransactionAPI(object):
             raise e
         return fields
 
-    def _add_params(self, params, credit_card=None, address=None):
+    def _add_params(self, params, credit_card=None, address=None, email=None):
         if credit_card:
             params.update({
                 'x_card_num': credit_card.card_number,
@@ -80,6 +80,10 @@ class TransactionAPI(object):
                 'x_first_name': credit_card.first_name,
                 'x_last_name': credit_card.last_name,
             })
+
+        if email:
+            params['x_email'] = email
+
         if address:
             params.update({
                 'x_address': address.street,
@@ -93,18 +97,18 @@ class TransactionAPI(object):
                 del params[key]
         return params
 
-    def auth(self, amount, credit_card, address=None):
+    def auth(self, amount, credit_card, address=None, email=None):
         amount = Decimal(str(amount)).quantize(Decimal('0.01'))
         params = self.base_params.copy()
-        params = self._add_params(params, credit_card, address)
+        params = self._add_params(params, credit_card, address, email)
         params['x_type'] = 'AUTH_ONLY'
         params['x_amount'] = str(amount)
         return self._make_call(params)
 
-    def capture(self, amount, credit_card, address=None):
+    def capture(self, amount, credit_card, address=None, email=None):
         amount = Decimal(str(amount)).quantize(Decimal('0.01'))
         params = self.base_params.copy()
-        params = self._add_params(params, credit_card, address)
+        params = self._add_params(params, credit_card, address, email)
         params['x_type'] = 'AUTH_CAPTURE'
         params['x_amount'] = str(amount)
         return self._make_call(params)

--- a/authorize/client.py
+++ b/authorize/client.py
@@ -114,7 +114,7 @@ class AuthorizeCreditCard(object):
         instance representing the transaction.
         """
         response = self._client._transaction.auth(
-            amount, self.credit_card, self.address)
+            amount, self.credit_card, self.address, self.email)
         transaction = self._client.transaction(response['transaction_id'])
         transaction.full_response = response
         return transaction
@@ -127,7 +127,7 @@ class AuthorizeCreditCard(object):
         instance representing the transaction.
         """
         response = self._client._transaction.capture(
-            amount, self.credit_card, self.address)
+            amount, self.credit_card, self.address, self.email)
         transaction = self._client.transaction(response['transaction_id'])
         transaction.full_response = response
         return transaction

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -82,7 +82,7 @@ class ClientTests(TestCase):
         card = AuthorizeCreditCard(self.client, self.credit_card)
         result = card.auth(10)
         self.assertEqual(self.client._transaction.auth.call_args,
-            ((10, self.credit_card, None), {}))
+            ((10, self.credit_card, None, None), {}))
         self.assertTrue(isinstance(result, AuthorizeTransaction))
         self.assertEqual(result.uid, '2171062816')
         self.assertEqual(result.full_response, TRANSACTION_RESULT)
@@ -92,7 +92,7 @@ class ClientTests(TestCase):
         card = AuthorizeCreditCard(self.client, self.credit_card)
         result = card.capture(10)
         self.assertEqual(self.client._transaction.capture.call_args,
-            ((10, self.credit_card, None), {}))
+            ((10, self.credit_card, None, None), {}))
         self.assertTrue(isinstance(result, AuthorizeTransaction))
         self.assertEqual(result.uid, '2171062816')
         self.assertEqual(result.full_response, TRANSACTION_RESULT)


### PR DESCRIPTION
This one is pretty self explanatory. E-mail is provided to CreditCard, but those details aren't passed along to `TransactionAPI.auth` or `TransactionAPI.capture`. This fixes that.

Otherwise, for some CC types, this error is raised:
`AuthorizeResponseError: Email is required. full_response={'cvv_response': '', 'authorization_code': '', 'response_code': '3', 'amount': '1.20', 'transaction_type': 'auth_only', 'avs_response': 'P', 'response_reason_code': '33', 'response_reason_text': 'Email is required.', 'transaction_id': '0'}`
