### PR TITLE
SSLError catching

### DIFF
--- a/authorize/apis/customer.py
+++ b/authorize/apis/customer.py
@@ -1,6 +1,7 @@
 from decimal import Decimal
 import urllib
 from datetime import datetime
+from ssl import SSLError
 
 from suds import WebFault
 from suds.client import Client
@@ -46,7 +47,7 @@ class CustomerAPI(object):
         method = getattr(self.client.service, service)
         try:
             response = method(self.client_auth, *args)
-        except WebFault as e:
+        except (WebFault, SSLError) as e:
             raise AuthorizeConnectionError('Error contacting SOAP API.')
         if response.resultCode != 'Ok':
             error = response.messages[0][0]

--- a/authorize/apis/recurring.py
+++ b/authorize/apis/recurring.py
@@ -1,5 +1,6 @@
 from datetime import date
 from decimal import Decimal
+from ssl import SSLError
 
 from suds import WebFault
 from suds.client import Client
@@ -38,7 +39,7 @@ class RecurringAPI(object):
         method = getattr(self.client.service, service)
         try:
             response = method(self.client_auth, *args)
-        except WebFault as e:
+        except (WebFault, SSLError) as e:
             raise AuthorizeConnectionError(e)
         if response.resultCode != 'Ok':
             error = response.messages[0][0]

--- a/tests/test_api_customer.py
+++ b/tests/test_api_customer.py
@@ -2,6 +2,7 @@ from datetime import date
 
 import mock
 from suds import WebFault
+from ssl import SSLError
 from unittest2 import TestCase
 
 from authorize.apis.customer import CustomerAPI, PROD_URL, TEST_URL
@@ -132,6 +133,13 @@ class CustomerAPITests(TestCase):
             'TestService', 'foo')
         self.assertEqual(self.api.client.service.TestService.call_args[0],
             (self.api.client_auth, 'foo'))
+
+    def test_make_call_ssl_error(self):
+        self.api.client.service.TestService.side_effect = SSLError('a', 'b')
+        self.assertRaises(AuthorizeConnectionError, self.api._make_call,
+                          'TestService', 'foo')
+        self.assertEqual(self.api.client.service.TestService.call_args[0],
+                         (self.api.client_auth, 'foo'))
 
     def test_make_call_response_error(self):
         self.api.client.service.TestService.return_value = ERROR

--- a/tests/test_api_recurring.py
+++ b/tests/test_api_recurring.py
@@ -2,6 +2,7 @@ from datetime import date, timedelta
 
 import mock
 from suds import WebFault
+from ssl import SSLError
 from unittest2 import TestCase
 
 from authorize.apis.recurring import PROD_URL, RecurringAPI, TEST_URL
@@ -73,6 +74,13 @@ class RecurringAPITests(TestCase):
             'TestService', 'foo')
         self.assertEqual(self.api.client.service.TestService.call_args[0],
             (self.api.client_auth, 'foo'))
+
+    def test_make_call_ssl_error(self):
+        self.api.client.service.TestService.side_effect = SSLError('a', 'b')
+        self.assertRaises(AuthorizeConnectionError, self.api._make_call,
+                          'TestService', 'foo')
+        self.assertEqual(self.api.client.service.TestService.call_args[0],
+                         (self.api.client_auth, 'foo'))
 
     def test_make_call_response_error(self):
         self.api.client.service.TestService.return_value = ERROR


### PR DESCRIPTION
Suds doesn't catch SSLErrors as part of its process. Webfault exceptions only seem to happen when we get connected far enough to have the server respond with a SOAP webfault. This PR allows AuthorizeSauce to intercept the Exception and reraise it as an `AuthorizeConnectionError`. It also increments the version number.