### PR TITLE
Added optional argument for using the USAePAY emulation

### DIFF
--- a/authorize/apis/transaction.py
+++ b/authorize/apis/transaction.py
@@ -7,6 +7,8 @@ from authorize.exceptions import AuthorizeConnectionError, \
 
 PROD_URL = 'https://secure.authorize.net/gateway/transact.dll'
 TEST_URL = 'https://test.authorize.net/gateway/transact.dll'
+PROD_URL_USAEPAY = 'https://secure.usaepay.com/gateway/transact.dll'
+TEST_URL_USAEPAY = 'https://sandboy.usaepay.com/gateway/transact.dll'
 RESPONSE_FIELDS = {
     0: 'response_code',
     2: 'response_reason_code',
@@ -44,8 +46,11 @@ def convert_params_to_byte_str(params):
 
 
 class TransactionAPI(object):
-    def __init__(self, login_id, transaction_key, debug=True, test=False):
-        self.url = TEST_URL if debug else PROD_URL
+    def __init__(self, login_id, transaction_key, debug=True, test=False, usaepay=False):
+        if not usaepay:
+            self.url = TEST_URL if debug else PROD_URL
+        else:
+            self.url = TEST_URL_USAEPAY if debug else PROD_URL_USAEPAY
         self.base_params = {
             'x_login': login_id,
             'x_tran_key': transaction_key,

--- a/authorize/client.py
+++ b/authorize/client.py
@@ -35,13 +35,14 @@ class AuthorizeClient(object):
     the standard API in test mode, which should generally be left ``False``,
     even in development and staging environments.
     """
-    def __init__(self, login_id, transaction_key, debug=True, test=False):
+    def __init__(self, login_id, transaction_key, debug=True, test=False, usaepay=False):
         self.login_id = login_id
         self.transaction_key = transaction_key
         self.debug = debug
         self.test = test
+        self.usaepay = usaepay
         self._transaction = TransactionAPI(login_id, transaction_key,
-            debug, test)
+            debug, test, usaepay)
         self._recurring = RecurringAPI(login_id, transaction_key, debug, test)
         self._customer = CustomerAPI(login_id, transaction_key, debug, test)
 


### PR DESCRIPTION
Added two constants, PROD_URL_USAEPAY and TEST_URL_USAEPAY, which point to the production and sandbox environment of USAePAY solution which provides authorize.net emulation. This way, authorize sauce can be used with that payment gateway with one additional argument, usaepay set to true while initializing AuthorizeClient.

More info [here](https://help.usaepay.com/developer/support/migration).