### PR TITLE
Switch from suds to suds-jurko

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-suds==0.4
+suds-jurko==0.6
 mock==0.8.0
 unittest2==0.5.1
 sphinx==1.1.3

--- a/setup.py
+++ b/setup.py
@@ -63,7 +63,7 @@ setup(
     long_description=__doc__,
     license='MIT',
     install_requires=[
-        'suds>=0.4',
+        'suds-jurko>=0.6',
     ],
     packages=[
         'authorize',


### PR DESCRIPTION
As explained at http://stackoverflow.com/a/14974075/25507, suds is no
longer maintained, and it throws errors in newer versions of Python 3.x.