### PR TITLE
Fix CVV validation regex

### DIFF
--- a/authorize/data.py
+++ b/authorize/data.py
@@ -56,7 +56,7 @@ class CreditCard(object):
             raise AuthorizeInvalidError('Credit card number is not valid.')
         if datetime.now() > self.expiration:
             raise AuthorizeInvalidError('Credit card is expired.')
-        if not re.match(r'^[\d+]{3,4}$', self.cvv):
+        if not re.match(r'^\d{3,4}$', self.cvv):
             raise AuthorizeInvalidError('Credit card CVV is invalid format.')
         if not self.card_type:
             raise AuthorizeInvalidError('Credit card number is not valid.')


### PR DESCRIPTION
The previous regex allowed '+' as a literal character, so numbers like '12+' were valid.  I assume this is an error.