### PR TITLE
Add eCheck support

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -47,6 +47,7 @@ Saucy Features
 * Save a credit card securely on Authorize.net's servers
 * Use saved cards to charge, auth and credit
 * Create recurring charges, with billing cycles, trial periods, etc.
+* Process an eCheck
 
 For the full documentation, please visit us at `Read the Docs`_. Thanks to
 Chewse_ for supporting the development and open-sourcing of this library.

--- a/authorize/__init__.py
+++ b/authorize/__init__.py
@@ -37,6 +37,6 @@ test
 """
 
 from authorize.client import AuthorizeClient
-from authorize.data import Address, CreditCard
+from authorize.data import Address, CreditCard, ECheckAccount
 from authorize.exceptions import AuthorizeConnectionError, AuthorizeError, \
     AuthorizeInvalidError, AuthorizeResponseError

--- a/authorize/client.py
+++ b/authorize/client.py
@@ -269,8 +269,8 @@ class AuthorizeTransaction(object):
 
     def void(self):
         """
-        Voids a previous authorization that has not yet been settled. Returns
-        an
+        Voids a previous credit card or eCheck authorization that has not yet
+        been settled. Returns an
         :class:`AuthorizeTransaction <authorize.client.AuthorizeTransaction>`
         instance representing the void transaction.
         """

--- a/authorize/data.py
+++ b/authorize/data.py
@@ -1,6 +1,6 @@
 """
-This module provides the data structures for describing credit cards and
-addresses for use in executing charges.
+This module provides the data structures for describing credit cards,
+addresses, and checking accounts for use in executing charges.
 """
 
 import calendar
@@ -96,6 +96,19 @@ class CreditCard(object):
             if re.match(card_type_re, self.card_number):
                 return card_type
 
+    def transaction_params(self):
+        """
+        Gets the Authorize.net API parameters to use to represent this
+        credit card.
+        """
+        return {
+            'x_card_num': self.card_number,
+            'x_exp_date': self.expiration.strftime('%m-%Y'),
+            'x_card_code': self.cvv,
+            'x_first_name': self.first_name,
+            'x_last_name': self.last_name,
+        }
+
 
 class Address(object):
     """
@@ -113,3 +126,60 @@ class Address(object):
     def __repr__(self):
         return '<Address {0.street}, {0.city}, {0.state} {0.zip_code}>' \
             .format(self)
+
+
+class ECheckAccount(object):
+    """
+    Represents an eCheck account that can be charged.
+
+    Note that eCheck.Net is a separate service through Authorize.net; you must
+    sign up for it separately.
+
+    ``routing_number``
+        9-digit ABA routing number for the back
+
+    ``account_number``
+        Account number
+
+    ``account_type``
+        ``'checking'``, ``'businesschecking'``, or ``'savings'``
+
+    ``bank_name``
+        Name of the bank
+
+    ``account_name``
+        The name on the account
+    """
+    ACCOUNT_TYPES = ('checking', 'businesschecking', 'savings')
+
+    def __init__(self, routing_number=None, account_number=None,
+            account_type=None, bank_name=None, account_name=None):
+        self.routing_number = str(routing_number)
+        self.account_number = str(account_number)
+        self.account_type = account_type
+        self.bank_name = bank_name
+        self.account_name = account_name
+
+    def validate(self):
+        """
+        See :func:`CreditCard.validate`.
+        """
+        if not re.match(r'^\d9$', self.routing_number):
+            raise AuthorizeInvalidError('Routing number should be a 9 digit number.')
+        if not re.match(r'^\d{1,20}$', self.account_number):
+            raise AuthorizeInvalidError('Account number should be a number between 1 and 20 digits.')
+        if self.account_type.lower() not in self.ACCOUNT_TYPES:
+            raise AuthorizeInvalidError('Invalid account type.')
+
+    def transaction_params(self):
+        """
+        Gets the Authorize.net API parameters to use to represent this
+        eCheck account.
+        """
+        return {
+            'x_bank_aba_code': self.routing_number,
+            'x_bank_acct_num': self.account_number,
+            'x_bank_acct_type': self.account_type.upper(),
+            'x_bank_name': self.bank_name,
+            'x_bank_acct_name': self.account_name,
+        }

--- a/authorize/data.py
+++ b/authorize/data.py
@@ -135,6 +135,8 @@ class ECheckAccount(object):
     Note that eCheck.Net is a separate service through Authorize.net; you must
     sign up for it separately.
 
+    All parameters are required.
+
     ``routing_number``
         9-digit ABA routing number for the back
 
@@ -153,23 +155,28 @@ class ECheckAccount(object):
     ACCOUNT_TYPES = ('checking', 'businesschecking', 'savings')
 
     def __init__(self, routing_number=None, account_number=None,
-            account_type=None, bank_name=None, account_name=None):
+            account_type='checking', bank_name=None, account_name=None):
         self.routing_number = str(routing_number)
         self.account_number = str(account_number)
         self.account_type = account_type
         self.bank_name = bank_name
         self.account_name = account_name
+        self.validate()
 
     def validate(self):
         """
         See :func:`CreditCard.validate`.
         """
-        if not re.match(r'^\d9$', self.routing_number):
+        if not re.match(r'^\d{9}$', self.routing_number):
             raise AuthorizeInvalidError('Routing number should be a 9 digit number.')
         if not re.match(r'^\d{1,20}$', self.account_number):
             raise AuthorizeInvalidError('Account number should be a number between 1 and 20 digits.')
         if self.account_type.lower() not in self.ACCOUNT_TYPES:
             raise AuthorizeInvalidError('Invalid account type.')
+        if self.bank_name is None:
+            raise AuthorizeInvalidError('Bank name is required.')
+        if self.account_name is None:
+            raise AuthorizeInvalidError('Account name is required.')
 
     def transaction_params(self):
         """

--- a/authorize/data.py
+++ b/authorize/data.py
@@ -169,8 +169,14 @@ class ECheckAccount(object):
         """
         if not re.match(r'^\d{9}$', self.routing_number):
             raise AuthorizeInvalidError('Routing number should be a 9 digit number.')
-        if not re.match(r'^\d{1,20}$', self.account_number):
-            raise AuthorizeInvalidError('Account number should be a number between 1 and 20 digits.')
+
+        # Authorize.Net's documentation doesn't give a minimum length, but
+        # testing shows that it rejects any account number < 5 digits.
+        # According to http://stackoverflow.com/a/1540314/25507, 4 is the
+        # minimum length.
+        if not re.match(r'^\d{5,20}$', self.account_number):
+            raise AuthorizeInvalidError('Account number should be a number between 5 and 20 digits.')
+
         if self.account_type.lower() not in self.ACCOUNT_TYPES:
             raise AuthorizeInvalidError('Invalid account type.')
         if self.bank_name is None:

--- a/authorize/data.py
+++ b/authorize/data.py
@@ -183,3 +183,32 @@ class ECheckAccount(object):
             'x_bank_name': self.bank_name,
             'x_bank_acct_name': self.account_name,
         }
+
+    @property
+    def safe_account_number(self):
+        """
+        The account number with all but the last four digits masked. This
+        is useful for storing a representation of the account without keeping
+        sensitive data.
+
+        This matches the format used by Authorize.Net in its administrative
+        interface: "XXXX" followed by the last four digits, regardless of the
+        length of the account number.
+        """
+        return 'XXXX' + self.account_number[-4:]
+
+    @property
+    def safe_routing_number(self):
+        """
+        The routing number with all but the last four digits masked.
+        Authorize.Net uses this format in its administrative interface.
+        Routing numbers are generally public knowledge (see, for example, the
+        American Banking Association's `search page`_), but which bank a
+        particular person uses is still sensitive data.
+
+        The format matches Authorize.Net: "XXXX" followed by the last four
+        digits, even though routing numbers are nine digits long.
+
+        .. _search page: http://routingnumber.aba.com/
+        """
+        return 'XXXX' + self.routing_number[-4:]

--- a/docs/client.rst
+++ b/docs/client.rst
@@ -7,7 +7,7 @@ Authorize client
 ----------------
 
 .. autoclass:: authorize.client.AuthorizeClient
-    :members: card, transaction, saved_card, recurring
+    :members: card, transaction, saved_card, recurring, echeck
 
 Credit card
 -----------
@@ -32,3 +32,9 @@ Recurring charge
 
 .. autoclass:: authorize.client.AuthorizeRecurring
     :members: update, delete
+
+eCheck
+------
+
+.. autoclass:: authorize.client.AuthorizeECheck
+    :members: web

--- a/docs/data.rst
+++ b/docs/data.rst
@@ -18,4 +18,4 @@ eCheck account
 --------------
 
 .. autoclass:: authorize.data.ECheckAccount
-    :members: validate
+    :members: validate, safe_account_number, safe_routing_number

--- a/docs/data.rst
+++ b/docs/data.rst
@@ -13,3 +13,9 @@ Address
 -------
 
 .. autoclass:: authorize.data.Address
+
+eCheck account
+--------------
+
+.. autoclass:: authorize.data.ECheckAccount
+    :members: validate

--- a/docs/development.rst
+++ b/docs/development.rst
@@ -101,11 +101,13 @@ fairly uninformative. That said, you can find it here:
 * `Advanced Integration Method`_
 * `Customer Information Manager`_
 * `Automated Recurring Billing`_
+* `eCheck.Net`_
 
 .. _Developer site: http://developer.authorize.net/
 .. _Advanced Integration Method: http://www.authorize.net/support/AIM_guide.pdf
 .. _Customer Information Manager: http://www.authorize.net/support/CIM_SOAP_guide.pdf
 .. _Automated Recurring Billing: http://www.authorize.net/support/ARB_SOAP_guide.pdf
+.. _eCheck.Net: http://www.authorize.net/support/AIM_guide.pdf
 
 Submitting bugs and patches
 ---------------------------

--- a/tests/test_api_transaction.py
+++ b/tests/test_api_transaction.py
@@ -83,7 +83,7 @@ class TransactionAPITests(TestCase):
         self.credit_card = CreditCard('4111111111111111', self.year, 1, '911')
         self.address = Address('45 Rose Ave', 'Venice', 'CA', '90291')
         self.echeck_account = ECheckAccount('123456789', '1234567',
-            account_type='checking')
+            bank_name='First Bank', account_name='John Doe')
 
     def test_basic_api(self):
         api = TransactionAPI('123', '456')
@@ -231,5 +231,6 @@ class TransactionAPITests(TestCase):
             '&x_amount=10.00&x_echeck_type=WEB&x_bank_acct_num=1234567'
             '&x_delim_char=%3B&x_tran_key=456&x_recurring_billing=FALSE'
             '&x_bank_aba_code=123456789&x_method=ECHECK&x_delim_data=TRUE'
-            '&x_bank_acct_type=CHECKING&x_login=123&x_test_request=FALSE'))
+            '&x_bank_acct_type=CHECKING&x_login=123&x_test_request=FALSE'
+            '&x_bank_name=First%20Bank&x_bank_acct_name=John%20Doe'))
         self.assertEqual(result, PARSED_SUCCESS)

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -50,7 +50,8 @@ class ClientTests(TestCase):
         self.credit_card = CreditCard('4111111111111111', self.year, 1, '911',
             'Jeff', 'Schenck')
         self.address = Address('45 Rose Ave', 'Venice', 'CA', '90291')
-        self.echeck_account = ECheckAccount('021000021', '1234567890', 'checking', 'First Bank', 'John Doe')
+        self.echeck_account = ECheckAccount('021000021', '1234567890',
+            'checking', 'First Bank', 'John Doe')
 
     def tearDown(self):
         self.transaction_api_patcher.stop()
@@ -249,7 +250,7 @@ class ClientTests(TestCase):
 
     def test_authorize_echeck_web(self):
         self.client._transaction.echeck_web.return_value = ECHECK_TRANSACTION_RESULT
-        echeck = AuthorizeECheck(self.client, self.echeck_account)
+        echeck = self.client.echeck(self.echeck_account)
         result = echeck.web(10)
         self.assertEqual(self.client._transaction.echeck_web.call_args,
             ((10, self.echeck_account, None, None, False), {}))

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -3,9 +3,9 @@ from datetime import date
 import mock
 from unittest2 import TestCase
 
-from authorize import Address, AuthorizeClient, CreditCard
-from authorize.client import AuthorizeCreditCard, AuthorizeRecurring, \
-    AuthorizeSavedCard, AuthorizeTransaction
+from authorize import Address, AuthorizeClient, CreditCard, ECheckAccount
+from authorize.client import AuthorizeCreditCard, AuthorizeECheck, \
+    AuthorizeRecurring, AuthorizeSavedCard, AuthorizeTransaction
 from test_api_customer import PROFILE
 
 
@@ -20,6 +20,19 @@ TRANSACTION_RESULT = {
     'response_reason_text': 'This transaction has been approved.',
     'transaction_id': '2171062816',
 }
+
+ECHECK_TRANSACTION_RESULT = {
+    'avs_response': 'P',
+    'amount': '10.00',
+    'authorization_code': '',
+    'response_code': '1',
+    'cvv_response': '',
+    'response_reason_text': 'This transaction has been approved.',
+    'transaction_id': '2239207440',
+    'transaction_type': 'auth_capture',
+    'response_reason_code': '1'
+}
+
 
 class ClientTests(TestCase):
     def setUp(self):
@@ -37,6 +50,7 @@ class ClientTests(TestCase):
         self.credit_card = CreditCard('4111111111111111', self.year, 1, '911',
             'Jeff', 'Schenck')
         self.address = Address('45 Rose Ave', 'Venice', 'CA', '90291')
+        self.echeck_account = ECheckAccount('021000021', '1234567890', 'checking', 'First Bank', 'John Doe')
 
     def tearDown(self):
         self.transaction_api_patcher.stop()
@@ -232,3 +246,13 @@ class ClientTests(TestCase):
         recurring.delete()
         self.assertEqual(self.client._recurring.delete_subscription.call_args,
             (('123',), {}))
+
+    def test_authorize_echeck_web(self):
+        self.client._transaction.echeck_web.return_value = ECHECK_TRANSACTION_RESULT
+        echeck = AuthorizeECheck(self.client, self.echeck_account)
+        result = echeck.web(10)
+        self.assertEqual(self.client._transaction.echeck_web.call_args,
+            ((10, self.echeck_account, None, None, False), {}))
+        self.assertTrue(isinstance(result, AuthorizeTransaction))
+        self.assertEqual(result.uid, '2239207440')
+        self.assertEqual(result.full_response, ECHECK_TRANSACTION_RESULT)

--- a/tests/test_data.py
+++ b/tests/test_data.py
@@ -2,7 +2,7 @@ from datetime import date, datetime, timedelta
 
 from unittest2 import TestCase
 
-from authorize.data import Address, CreditCard
+from authorize.data import Address, CreditCard, ECheckAccount
 from authorize.exceptions import AuthorizeInvalidError
 
 
@@ -61,3 +61,17 @@ class AddressTests(TestCase):
     def test_basic_address(self):
         address = Address('45 Rose Ave', 'Venice', 'CA', '90291')
         repr(address)
+
+
+class ECheckTests(TestCase):
+    # Taken from https://www.wepay.com/developer/reference/testing
+    # Authorize.Net forum posts say any routing number will work for testing.
+    ROUTING_NUMBER = '021000021'
+
+    def test_safe_routing_number(self):
+        echeck = ECheckAccount(self.ROUTING_NUMBER, '1234567890')
+        self.assertEqual(echeck.safe_routing_number, 'XXXX0021')
+
+    def test_safe_account_number(self):
+        echeck = ECheckAccount(self.ROUTING_NUMBER, '1234567890')
+        self.assertEqual(echeck.safe_account_number, 'XXXX7890')

--- a/tests/test_data.py
+++ b/tests/test_data.py
@@ -69,9 +69,30 @@ class ECheckTests(TestCase):
     ROUTING_NUMBER = '021000021'
 
     def test_safe_routing_number(self):
-        echeck = ECheckAccount(self.ROUTING_NUMBER, '1234567890')
+        echeck = ECheckAccount(self.ROUTING_NUMBER, '1234567890',
+            bank_name='First Bank', account_name='John Doe')
         self.assertEqual(echeck.safe_routing_number, 'XXXX0021')
 
     def test_safe_account_number(self):
-        echeck = ECheckAccount(self.ROUTING_NUMBER, '1234567890')
+        echeck = ECheckAccount(self.ROUTING_NUMBER, '1234567890',
+            bank_name='First Bank', account_name='John Doe')
         self.assertEqual(echeck.safe_account_number, 'XXXX7890')
+
+    def test_account_validation(self):
+        # Too-long and too-short routing numbers
+        self.assertRaisesRegexp(AuthorizeInvalidError, '(?i)routing number',
+            ECheckAccount, '12345678', '123456', 'checking', 'First Bank', 'John Doe')
+        self.assertRaisesRegexp(AuthorizeInvalidError, '(?i)routing number',
+            ECheckAccount, '1234567890', '123456', 'checking', 'First Bank', 'John Doe')
+
+        # Account number, type
+        self.assertRaisesRegexp(AuthorizeInvalidError, '(?i)account number',
+            ECheckAccount, '123456789', 'not-a-number', 'checking', 'First Bank', 'John Doe')
+        self.assertRaisesRegexp(AuthorizeInvalidError, '(?i)account type',
+            ECheckAccount, '123456789', '123456', 'freemoney', 'First Bank', 'John Doe')
+
+        # Names
+        self.assertRaisesRegexp(AuthorizeInvalidError, '(?i)bank name',
+            ECheckAccount, '123456789', '123456', 'checking', None, 'John Doe')
+        self.assertRaisesRegexp(AuthorizeInvalidError, '(?i)account name',
+            ECheckAccount, '123456789', '123456', 'checking', 'First Bank', None)


### PR DESCRIPTION
eCheck processing uses the same AIM API as credit cards, just with a somewhat different set of parameters.

Authorize.Net offers several eCheck transaction types; for now, I've only implemented WEB (for taking eChecks over the Internet).

To accommodate both credit cards and eChecks, the transaction API now takes a generic "account" instead of a credit card specifically.  I moved credit card API parameters logic to the CreditCard class so that eCheck accounts can generate a different set of parameters.
